### PR TITLE
JSX에서 사용한 다중 컴포넌트 추출

### DIFF
--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { getUsedComponents } from '@/core/parser';
+import { getDefinedComponents } from '@/core/parser';
 import { parseFile, readFileSync } from '@/utils/file';
 
 const entryPath = path.resolve(__dirname, '../../example/index.jsx');
@@ -8,7 +8,7 @@ const entryPath = path.resolve(__dirname, '../../example/index.jsx');
 const analyzer = () => {
   const code = readFileSync(entryPath);
   const ast = parseFile(code);
-  const components = getUsedComponents(ast);
+  const components = getDefinedComponents(ast);
 
   console.log(components);
 };


### PR DESCRIPTION
### 내용

- #8 에서 정의한 `getUsedComponents` 함수를 이용해서 JSX 파일에서 정의된 여러 컴포넌트를 분리해서 추출
- 선언된 컴포넌트 이름과 사용된 컴포넌트 이름들을 키로 갖는 객체 배열이 반환됨
- 컴포넌트를 계층 구조로 나타낼 때 import 뿐만 아니라 한 JSX에서 선언해서 만들 수 있기 때문에 미리 대응