### PR TITLE
Import 및 Export 처리

### DIFF
--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -1,5 +1,6 @@
+import { analyzeFile } from '@/core/collector';
 import printTree from '@/core/console';
-import { analyzeFile, buildHierarchy } from '@/core/parser';
+import { buildHierarchy } from '@/core/parser';
 import { FilterOptions, Path } from '@/types';
 
 const analyzer = (entry: Path, options: FilterOptions = {}) => {

--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -1,0 +1,123 @@
+import traverse from '@babel/traverse';
+import {
+  isArrowFunctionExpression,
+  isFunctionExpression,
+  isIdentifier,
+  isImportDefaultSpecifier,
+  isImportSpecifier,
+  isJSXElement,
+  isJSXFragment,
+} from '@babel/types';
+
+import type { AST, Definition, Name, Node, Path } from '@/types';
+import { parseFile, readFileSync } from '@/utils/file';
+import { resolvePath } from '@/utils/path';
+
+export const analyzeFile = (entry: Path) => {
+  const analyzedFiles = new Set<Path>();
+  const allDefinitions = new Map<Name, Definition>();
+
+  const traverseFile = (path: Path) => {
+    if (analyzedFiles.has(path)) return;
+
+    try {
+      const code = readFileSync(path);
+      const ast = parseFile(code);
+      const importPaths = getImportPaths(ast, path);
+      const definitions = getDefinitions(ast, path);
+
+      analyzedFiles.add(path);
+
+      definitions.forEach((component, name) => {
+        allDefinitions.set(name, component);
+      });
+
+      for (const importPath of importPaths) {
+        traverseFile(importPath);
+      }
+    } catch {
+      console.error('Failed to analyze', path);
+    }
+  };
+
+  traverseFile(entry);
+
+  return allDefinitions;
+};
+
+const getImportPaths = (ast: AST, currentPath: Path) => {
+  const set = new Set<Path>();
+
+  traverse(ast, {
+    ImportDeclaration({ node }) {
+      const importSource = node.source.value;
+      const resolvedPath = resolvePath(currentPath, importSource);
+
+      if (!resolvedPath) return;
+
+      node.specifiers.forEach(spec => {
+        if (isImportSpecifier(spec) || isImportDefaultSpecifier(spec)) {
+          set.add(resolvedPath);
+        }
+      });
+    },
+  });
+
+  return set;
+};
+
+const getDefinitions = (ast: AST, sourcePath: Path) => {
+  const components = new Map<Name, Definition>();
+
+  traverse(ast, {
+    FunctionDeclaration(path) {
+      const name = path.node.id?.name;
+
+      if (name) {
+        let node: Node = null;
+
+        path.traverse({
+          ReturnStatement(retPath) {
+            const argument = retPath.node.argument;
+
+            if (isJSXElement(argument) || isJSXFragment(argument)) {
+              node = argument;
+            }
+          },
+        });
+
+        components.set(name, { name, path: sourcePath, node });
+      }
+    },
+    VariableDeclarator(path) {
+      const id = path.node.id;
+      const name = isIdentifier(id) ? id.name : null;
+
+      if (name) {
+        const init = path.node.init;
+
+        if (isArrowFunctionExpression(init) || isFunctionExpression(init)) {
+          let node: Node = null;
+
+          if (isJSXElement(init.body) || isJSXFragment(init.body)) {
+            node = init.body;
+          } else {
+            path.traverse({
+              ReturnStatement(retPath) {
+                const argument = retPath.node.argument;
+
+                if (isJSXElement(argument) || isJSXFragment(argument)) {
+                  node = argument;
+                }
+              },
+            });
+          }
+
+          components.set(name, { name, path: sourcePath, node });
+        }
+      }
+    },
+  });
+
+  return components;
+};

--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -4,6 +4,7 @@ import {
   isFunctionExpression,
   isIdentifier,
   isImportDefaultSpecifier,
+  isImportNamespaceSpecifier,
   isImportSpecifier,
   isJSXElement,
   isJSXFragment,
@@ -56,10 +57,32 @@ const getImportPaths = (ast: AST, currentPath: Path) => {
       if (!resolvedPath) return;
 
       node.specifiers.forEach(spec => {
-        if (isImportSpecifier(spec) || isImportDefaultSpecifier(spec)) {
+        if (
+          isImportSpecifier(spec) ||
+          isImportDefaultSpecifier(spec) ||
+          isImportNamespaceSpecifier(spec)
+        ) {
           set.add(resolvedPath);
         }
       });
+    },
+    ExportNamedDeclaration({ node }) {
+      if (!node.source) return;
+
+      const exportSource = node.source.value;
+      const resolvedPath = resolvePath(currentPath, exportSource);
+
+      if (resolvedPath) {
+        set.add(resolvedPath);
+      }
+    },
+    ExportAllDeclaration({ node }) {
+      const exportSource = node.source.value;
+      const resolvedPath = resolvePath(currentPath, exportSource);
+
+      if (resolvedPath) {
+        set.add(resolvedPath);
+      }
     },
   });
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,10 +1,5 @@
-import traverse from '@babel/traverse';
 import {
-  isArrowFunctionExpression,
-  isFunctionExpression,
   isIdentifier,
-  isImportDefaultSpecifier,
-  isImportSpecifier,
   isJSXElement,
   isJSXExpressionContainer,
   isJSXFragment,
@@ -14,118 +9,7 @@ import {
   JSXMemberExpression,
 } from '@babel/types';
 
-import type { AST, Component, Definition, Name, Node, Path, Root } from '@/types';
-import { parseFile, readFileSync } from '@/utils/file';
-import { resolvePath } from '@/utils/path';
-
-export const analyzeFile = (entry: Path) => {
-  const analyzedFiles = new Set<Path>();
-  const allDefinitions = new Map<Name, Definition>();
-
-  const traverseFile = (path: Path) => {
-    if (analyzedFiles.has(path)) return;
-
-    try {
-      const code = readFileSync(path);
-      const ast = parseFile(code);
-      const importPaths = getImportPaths(ast, path);
-      const definitions = getDefinitions(ast, path);
-
-      analyzedFiles.add(path);
-
-      definitions.forEach((component, name) => {
-        allDefinitions.set(name, component);
-      });
-
-      for (const importPath of importPaths) {
-        traverseFile(importPath);
-      }
-    } catch {
-      console.error('Failed to analyze', path);
-    }
-  };
-
-  traverseFile(entry);
-
-  return allDefinitions;
-};
-
-const getImportPaths = (ast: AST, currentPath: Path) => {
-  const set = new Set<Path>();
-
-  traverse(ast, {
-    ImportDeclaration({ node }) {
-      const importSource = node.source.value;
-      const resolvedPath = resolvePath(currentPath, importSource);
-
-      if (!resolvedPath) return;
-
-      node.specifiers.forEach(spec => {
-        if (isImportSpecifier(spec) || isImportDefaultSpecifier(spec)) {
-          set.add(resolvedPath);
-        }
-      });
-    },
-  });
-
-  return set;
-};
-
-const getDefinitions = (ast: AST, sourcePath: Path) => {
-  const components = new Map<Name, Definition>();
-
-  traverse(ast, {
-    FunctionDeclaration(path) {
-      const name = path.node.id?.name;
-
-      if (name) {
-        let node: Node = null;
-
-        path.traverse({
-          ReturnStatement(retPath) {
-            const argument = retPath.node.argument;
-
-            if (isJSXElement(argument) || isJSXFragment(argument)) {
-              node = argument;
-            }
-          },
-        });
-
-        components.set(name, { name, path: sourcePath, node });
-      }
-    },
-    VariableDeclarator(path) {
-      const id = path.node.id;
-      const name = isIdentifier(id) ? id.name : null;
-
-      if (name) {
-        const init = path.node.init;
-
-        if (isArrowFunctionExpression(init) || isFunctionExpression(init)) {
-          let node: Node = null;
-
-          if (isJSXElement(init.body) || isJSXFragment(init.body)) {
-            node = init.body;
-          } else {
-            path.traverse({
-              ReturnStatement(retPath) {
-                const argument = retPath.node.argument;
-
-                if (isJSXElement(argument) || isJSXFragment(argument)) {
-                  node = argument;
-                }
-              },
-            });
-          }
-
-          components.set(name, { name, path: sourcePath, node });
-        }
-      }
-    },
-  });
-
-  return components;
-};
+import type { Component, Definition, Name, Node, Path, Root } from '@/types';
 
 export const buildHierarchy = (sourcePath: Path, allDefinitions: Map<Name, Definition>) => {
   const tree: Root = {

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -69,7 +69,7 @@ const processNode = (node: Node, allDefinitions: Map<Name, Definition>): Compone
 
   // JSX Element 처리
   const name = getJSXName(node);
-  const definition = allDefinitions.get(name);
+  const definition = allDefinitions.get(name.split('.').at(-1)!);
 
   if (definition) {
     const childComponents: Component[] = [];


### PR DESCRIPTION
### 내용

namespace import와 named export 및 all export 패턴을 `getImportPaths` 함수에서 처리할 수 있도록 수정

- namespace import: isImportNamspaceSpecifier로 검증
- named export: ExportNameDeclaration으로 처리
- all export: ExportAllDeclaration으로 처리

```
// Namespace Import
import * as ReExport from './re-export';

// Named Export
export { default as Foo } from './foo';

// All Export
export * as Bar from './bar
```