### PR TITLE
중복 Import Component 해결

### DIFF
--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -4,9 +4,9 @@ import { buildHierarchy } from '@/core/parser';
 import { FilterOptions, Path } from '@/types';
 
 const analyzer = (entry: Path, options: FilterOptions = {}) => {
-  const { allImports, allDefinitions } = analyzeFile(entry);
+  const context = analyzeFile(entry);
 
-  const tree = buildHierarchy(entry, allDefinitions, allImports);
+  const tree = buildHierarchy(entry, context);
 
   const components = Object.values(tree.components);
   const component = components.find(component => component !== null);

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -4,8 +4,9 @@ import { buildHierarchy } from '@/core/parser';
 import { FilterOptions, Path } from '@/types';
 
 const analyzer = (entry: Path, options: FilterOptions = {}) => {
-  const allDefinitions = analyzeFile(entry);
-  const tree = buildHierarchy(entry, allDefinitions);
+  const { allImports, allDefinitions } = analyzeFile(entry);
+
+  const tree = buildHierarchy(entry, allDefinitions, allImports);
 
   const components = Object.values(tree.components);
   const component = components.find(component => component !== null);

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -5,7 +5,6 @@ import { FilterOptions, Path } from '@/types';
 
 const analyzer = (entry: Path, options: FilterOptions = {}) => {
   const context = analyzeFile(entry);
-
   const tree = buildHierarchy(entry, context);
 
   const components = Object.values(tree.components);

--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -93,6 +93,12 @@ const getDefinitions = (ast: AST, sourcePath: Path) => {
   const components = new Map<Name, Definition>();
 
   traverse(ast, {
+    JSXElement(path) {
+      path.node.extra = { ...(path.node.extra || {}), sourcePath };
+    },
+    JSXFragment(path) {
+      path.node.extra = { ...(path.node.extra || {}), sourcePath };
+    },
     FunctionDeclaration(path) {
       const name = path.node.id?.name;
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -17,13 +17,13 @@ export const buildHierarchy = (sourcePath: Path, context: Context) => {
     components: {},
   };
 
-  for (const [name, definition] of context.allDefinitions) {
+  for (const [, definition] of context.allDefinitions) {
     // root에 정의되지 않은 컴포넌트는 처리하지 않음
     if (sourcePath !== definition.path) continue;
 
-    tree.components[name] = {
+    tree.components[definition.name] = {
       type: 'COMPONENT',
-      name,
+      name: definition.name,
       path: definition.path,
       render: processNode(definition.node, context),
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,11 @@ export type Definition = {
   node: Node;
 };
 
+export type Context = {
+  allImports: Map<Key, Path>;
+  allDefinitions: Map<Key, Definition>;
+};
+
 export type Node =
   | JSXText
   | JSXElement


### PR DESCRIPTION
### 내용

기존에는 모든 import문을 분석해서 `컴포넌트 이름 -> 컴포넌트 정의` 맵 구조로 만들어서 처리했음. 그러나 다른 파일에 정의된 컴포넌트를 같은 이름으로 import하는 경우 덮어쓰기 되는 문제가 발생함.

그래서 컴포넌트 별로 고유한 식별자를 갖도록 `정의된 경로 :: 컴포넌트 이름 -> 컴포넌트 정의` 맵 구조로 만들어서 이 문제를 해결함. 다만 기존에는 분석 중인 Node가 어디서 정의된 컴포넌트인지 알 수 있는 방법이 없었기 때문에 몇 가지 처리를 함.

- 모든 Node를 분석하는 중에 사용된 경로를 저장함 -> `node.extra.originPath`
- 컴포넌트의 사용된 경로와 정의된 경로를 연결하는 구조를 만듦 -> `사용된 경로 :: 컴포넌트 이름 -> 정의된 경로`

경로를 분석하는 과정을 간단히 표현하면 아래와 같음

1. JSX Element를 처리하는 중 사용된 경로(originPath)를 `node.extra.originPath`에서 가져옴
2. `사용된 경로 :: 컴포넌트 이름`을 통해 `정의된 경로`를 찾음
  2-1. 존재하는 경우: 외부에서 정의한 컴포넌트이기 때문에 `정의된 경로 :: 컴포넌트 이름`으로 import한 컴포넌트 정의를 식별해서 처리
  2-2. 존재하지 않는 경우: 내부에서 정의한 컴포넌트(사용된 경로 == 정의된 경로) 혹은 HTML Node이기 때문에 먼저 `사용된 경로 :: 컴포넌트 이름`으로 내부에서 정의된 컴포넌트를 식별해서 처리
  2-3. 내부에도 존재하지 않는 경우: HTML Node이기 때문에 이에 맞춰서 처리